### PR TITLE
feat(postgres): add POSTGRES_SKIP_PROVISIONING option

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -6,6 +6,7 @@ export const defaultConfig: Partial<Config> = {
     username: 'postgres',
     password: '', // Will be required via validation
     database: 'servarr',
+    skipProvisioning: false,
   },
   servarr: {
     url: '', // Will be required via validation
@@ -37,6 +38,7 @@ export const envMapping = {
   POSTGRES_PASSWORD: 'postgres.password',
   POSTGRES_DB: 'postgres.database',
   POSTGRES_DATABASE: 'postgres.database', // Alternative name
+  POSTGRES_SKIP_PROVISIONING: 'postgres.skipProvisioning',
 
   SERVARR_URL: 'servarr.url',
   SERVARR_TYPE: 'servarr.type',

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -9,6 +9,7 @@ export function loadEnvironmentConfig(): Config {
       username: env.POSTGRES_USER,
       password: env.POSTGRES_PASSWORD || '',
       database: env.POSTGRES_DB,
+      skipProvisioning: env.POSTGRES_SKIP_PROVISIONING === 'true',
     },
     servarr: {
       url: env.SERVARR_URL || '',

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -6,6 +6,7 @@ export const PostgresConfigSchema = z.object({
   username: z.string().default('postgres'),
   password: z.string(),
   database: z.string().default('servarr'),
+  skipProvisioning: z.boolean().default(false),
 })
 
 export const ServarrConfigSchema = z

--- a/src/steps/infrastructure/postgres-databases.ts
+++ b/src/steps/infrastructure/postgres-databases.ts
@@ -13,6 +13,11 @@ export class PostgresDatabasesStep extends ConfigurationStep {
   readonly mode: 'init' | 'sidecar' | 'both' = 'init'
 
   validatePrerequisites(context: StepContext): boolean {
+    // Skip if provisioning is disabled (for pre-provisioned databases)
+    if (context.config.postgres.skipProvisioning) {
+      context.logger.info('PostgreSQL provisioning skipped (POSTGRES_SKIP_PROVISIONING=true)')
+      return false
+    }
     // Only run in init mode
     return context.executionMode === 'init'
   }

--- a/src/steps/infrastructure/postgres-users.ts
+++ b/src/steps/infrastructure/postgres-users.ts
@@ -13,6 +13,11 @@ export class PostgresUsersStep extends ConfigurationStep {
   readonly mode: 'init' | 'sidecar' | 'both' = 'init'
 
   validatePrerequisites(context: StepContext): boolean {
+    // Skip if provisioning is disabled (for pre-provisioned databases)
+    if (context.config.postgres.skipProvisioning) {
+      context.logger.info('PostgreSQL user provisioning skipped (POSTGRES_SKIP_PROVISIONING=true)')
+      return false
+    }
     return context.executionMode === 'init'
   }
 


### PR DESCRIPTION
## Summary
- Add `POSTGRES_SKIP_PROVISIONING=true` environment variable to skip database/user/permission provisioning
- Enables secure, least-privilege deployments for pre-provisioned databases (e.g., CloudNativePG in Kubernetes)
- When enabled, skips `postgres-databases` and `postgres-users` steps entirely

## Test plan
- [x] TypeScript type checking passes
- [x] All 138 tests pass
- [ ] Manual testing with `POSTGRES_SKIP_PROVISIONING=true` in a Kubernetes environment

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to skip PostgreSQL provisioning during initialization. Set the `POSTGRES_SKIP_PROVISIONING` environment variable to `true` to bypass database and user setup. Useful for externally managed or pre-configured PostgreSQL instances.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->