### PR TITLE
fix: improve type compatibility for newer type definitions

### DIFF
--- a/src/config/loaders/file.ts
+++ b/src/config/loaders/file.ts
@@ -72,7 +72,7 @@ function parseJSON(content: string): Partial<Config> {
  */
 function parseYAML(content: string): Partial<Config> {
   try {
-    return YAML.parse(content)
+    return YAML.parse(content) as Partial<Config>
   } catch (error) {
     throw new Error(`Invalid YAML: ${error instanceof Error ? error.message : String(error)}`)
   }
@@ -83,7 +83,7 @@ function parseYAML(content: string): Partial<Config> {
  */
 function parseTOML(content: string): Partial<Config> {
   try {
-    return TOML.parse(content)
+    return TOML.parse(content) as Partial<Config>
   } catch (error) {
     throw new Error(`Invalid TOML: ${error instanceof Error ? error.message : String(error)}`)
   }

--- a/src/core/health.ts
+++ b/src/core/health.ts
@@ -1,6 +1,5 @@
 import type { ReconciliationManager, ReconciliationState } from '@/core/reconciliation'
 import { logger } from '@/utils/logger'
-import type { Server } from 'bun'
 
 export interface HealthStatus {
   status: 'healthy' | 'unhealthy' | 'starting'
@@ -22,7 +21,7 @@ export interface HealthStatus {
 }
 
 export class HealthServer {
-  private server: Server | undefined = undefined
+  private server: ReturnType<typeof Bun.serve> | undefined = undefined
   private startTime: Date = new Date()
   private reconciliationManager?: ReconciliationManager
   private healthStatus: HealthStatus['status'] = 'starting'

--- a/src/servarr/client.ts
+++ b/src/servarr/client.ts
@@ -868,10 +868,12 @@ export class ServarrManager {
     const encoder = new TextEncoder()
     const passwordBytes = encoder.encode(password)
     const key = await crypto.subtle.importKey('raw', passwordBytes, 'PBKDF2', false, ['deriveBits'])
+    // Create a new Uint8Array backed by a regular ArrayBuffer for PBKDF2 compatibility
+    const salt = new Uint8Array(saltArray.buffer.slice(0)) as Uint8Array<ArrayBuffer>
     const hashBuffer = await crypto.subtle.deriveBits(
       {
         name: 'PBKDF2',
-        salt: saltArray,
+        salt,
         iterations: 10000,
         hash: 'SHA-512',
       },


### PR DESCRIPTION
## Summary
- Add type assertions for `YAML.parse` and `TOML.parse` return values (fixes `unknown` type errors)
- Use `ReturnType<typeof Bun.serve>` instead of `Server` generic (fixes missing type argument error)
- Fix `Uint8Array` buffer slice for PBKDF2 salt compatibility (fixes `ArrayBufferLike` vs `ArrayBuffer` error)

## Context
These changes ensure compatibility with newer type definition packages:
- `@types/bun ^1.3.6`
- `@types/node v25`
- `bun-types ^1.3.6`

Once this PR is merged, the Renovate PRs for these packages can be rebased and will pass CI.

## Test plan
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run test` passes (138 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety and consistency in configuration and server handling.
  * Enhanced internal password hashing implementation for better compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->