### PR TITLE
fix(ci): add Node.js 22 setup for semantic-release compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,18 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      
+
       - name: Install dependencies
         run: bun install
-      
+
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Fixes CI release job failure caused by Node.js version incompatibility
- `semantic-release` now requires `^22.14.0 || >= 24.10.0`, but the runner has v24.3.0
- Adds `actions/setup-node@v4` with Node.js 22 to ensure compatibility

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Merge and confirm release job succeeds on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI pipeline to configure Node.js version 22 during the release build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->