### PR TITLE
Migrate Helm distribution from GitHub Pages to OCI

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -85,38 +85,18 @@ jobs:
           helm package helm/preparr
           echo "✓ Helm chart packaged as ${{ env.CHART_NAME }}-${{ steps.version.outputs.version }}.tgz"
 
-      - name: Checkout gh-pages branch
-        uses: actions/checkout@v6
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          ref: gh-pages
-          path: gh-pages
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update Helm repository
+      - name: Push chart to GHCR
         run: |
-          # Create directory if it doesn't exist
-          mkdir -p gh-pages
-
-          # Copy new chart to gh-pages
-          cp ${{ env.CHART_NAME }}-${{ steps.version.outputs.version }}.tgz gh-pages/
-
-          # Create ArtifactHub metadata file at repository root
-          cat > gh-pages/artifacthub-repo.yml <<EOF
-          repositoryID: preparr
-          owners:
-            - name: Robbe Verhelst
-              email: robbe@verhelst.io
-          EOF
-
-          # Generate/update index.yaml
-          helm repo index gh-pages --url https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
-
-          # Commit and push to gh-pages
-          cd gh-pages
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git add .
-          git commit -m "Release ${{ env.CHART_NAME }}-${{ steps.version.outputs.version }}" || echo "No changes to commit"
-          git push origin gh-pages
+          helm push ${{ env.CHART_NAME }}-${{ steps.version.outputs.version }}.tgz \
+            oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts
+          echo "✓ Chart pushed to oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts/${{ env.CHART_NAME }}:${{ steps.version.outputs.version }}"
 
       - name: Update release notes and attach chart
         uses: softprops/action-gh-release@v2
@@ -132,17 +112,19 @@ jobs:
 
             ### Helm Chart Installation
 
-            **From Helm Repository (Recommended):**
+            **From OCI Registry (Recommended):**
             ```bash
-            # Add the Helm repository
-            helm repo add preparr https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
-            helm repo update
+            helm install my-media-stack \
+              oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts/${{ env.CHART_NAME }} \
+              --version ${{ steps.version.outputs.version }}
+            ```
 
-            # Install the chart
-            helm install my-media-stack preparr/${{ env.CHART_NAME }} --version ${{ steps.version.outputs.version }}
-
-            # Or search for available versions
-            helm search repo preparr
+            **With custom values:**
+            ```bash
+            helm install my-media-stack \
+              oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts/${{ env.CHART_NAME }} \
+              --version ${{ steps.version.outputs.version }} \
+              -f custom-values.yaml
             ```
 
             **Direct from GitHub Release:**

--- a/README.md
+++ b/README.md
@@ -226,15 +226,11 @@ Each service gets its own init + sidecar containers managing separate config fil
 ### Helm Chart (Recommended)
 
 ```bash
-# Add the Helm repository
-helm repo add preparr https://robbeverhelst.github.io/Preparr
-helm repo update
-
 # Install the complete stack
-helm install my-media-stack preparr/preparr
+helm install my-media-stack oci://ghcr.io/robbeverhelst/charts/preparr --version <version>
 
 # Or with custom values
-helm install my-media-stack preparr/preparr -f custom-values.yaml
+helm install my-media-stack oci://ghcr.io/robbeverhelst/charts/preparr --version <version> -f custom-values.yaml
 ```
 
 Find the chart on [ArtifactHub](https://artifacthub.io/packages/helm/preparr/preparr) or see the [Helm chart documentation](helm/preparr/README.md).

--- a/docs/src/content/docs/deployment/helm.md
+++ b/docs/src/content/docs/deployment/helm.md
@@ -14,18 +14,11 @@ The Helm chart deploys a complete media automation stack including PostgreSQL, q
 ## Quick Start
 
 ```bash
-# Add the Helm repository
-helm repo add preparr https://robbeverhelst.github.io/Preparr
-helm repo update
-
 # Install with default values
-helm install my-media-stack preparr/preparr
+helm install my-media-stack oci://ghcr.io/robbeverhelst/charts/preparr --version <version>
 
 # Or install with custom values
-helm install my-media-stack preparr/preparr -f custom-values.yaml
-
-# View all available versions
-helm search repo preparr --versions
+helm install my-media-stack oci://ghcr.io/robbeverhelst/charts/preparr --version <version> -f custom-values.yaml
 ```
 
 The chart is also available on [ArtifactHub](https://artifacthub.io/packages/helm/preparr/preparr).
@@ -164,7 +157,7 @@ prowlarr:
 
 ```bash
 # Upgrade with new values
-helm upgrade media-stack preparr/preparr -f values.yaml
+helm upgrade media-stack oci://ghcr.io/robbeverhelst/charts/preparr --version <version> -f values.yaml
 
 # Uninstall
 helm uninstall media-stack

--- a/docs/src/content/docs/reference/helm-values.md
+++ b/docs/src/content/docs/reference/helm-values.md
@@ -6,9 +6,8 @@ description: Complete parameter reference for the PrepArr Helm chart
 The PrepArr Helm chart deploys a complete media automation stack. Install it from the Helm repository or from a local checkout.
 
 ```bash
-# From repository
-helm repo add preparr https://robbeverhelst.github.io/Preparr
-helm install media-stack preparr/preparr -f values.yaml
+# From OCI registry
+helm install media-stack oci://ghcr.io/robbeverhelst/charts/preparr --version <version> -f values.yaml
 
 # From local checkout
 helm install media-stack ./helm/preparr -f values.yaml
@@ -222,13 +221,13 @@ sonarr:
 ### Install
 
 ```bash
-helm install media-stack preparr/preparr -f values.yaml
+helm install media-stack oci://ghcr.io/robbeverhelst/charts/preparr --version <version> -f values.yaml
 ```
 
 ### Upgrade
 
 ```bash
-helm upgrade media-stack preparr/preparr -f values.yaml
+helm upgrade media-stack oci://ghcr.io/robbeverhelst/charts/preparr --version <version> -f values.yaml
 ```
 
 ### Uninstall
@@ -245,8 +244,8 @@ kubectl delete namespace preparr
 helm lint ./helm/preparr
 
 # Dry run
-helm install test preparr/preparr --dry-run --debug
+helm install test oci://ghcr.io/robbeverhelst/charts/preparr --version <version> --dry-run --debug
 
-# Template output
-helm template test preparr/preparr > output.yaml
+# Template output (from local checkout)
+helm template test ./helm/preparr > output.yaml
 ```

--- a/helm/preparr/README.md
+++ b/helm/preparr/README.md
@@ -10,21 +10,14 @@ Complete Infrastructure as Code for Servarr applications using Helm. Deploy your
 
 ## Quick Start
 
-### 1. Install from Helm Repository (Recommended)
+### 1. Install from OCI Registry (Recommended)
 
 ```bash
-# Add the Helm repository
-helm repo add preparr https://robbeverhelst.github.io/Preparr
-helm repo update
-
 # Install with default values
-helm install my-media-stack preparr/preparr
+helm install my-media-stack oci://ghcr.io/robbeverhelst/charts/preparr --version <version>
 
 # Or install with custom values
-helm install my-media-stack preparr/preparr -f custom-values.yaml
-
-# View all available versions
-helm search repo preparr --versions
+helm install my-media-stack oci://ghcr.io/robbeverhelst/charts/preparr --version <version> -f custom-values.yaml
 ```
 
 Find this chart on [ArtifactHub](https://artifacthub.io/packages/helm/preparr/preparr).
@@ -426,10 +419,7 @@ radarr:
 
 ```bash
 # Upgrade with new values
-helm upgrade media-stack ./preparr -f custom-values.yaml
-
-# Upgrade to new chart version
-helm upgrade media-stack ./preparr --version 0.2.0
+helm upgrade media-stack oci://ghcr.io/robbeverhelst/charts/preparr --version <version> -f custom-values.yaml
 ```
 
 ## Uninstall


### PR DESCRIPTION
Switch from legacy gh-pages index.yaml to modern OCI-based distribution on GHCR.

This resolves the Artifact Hub 404 error caused by the Starlight docs site and Helm chart artifacts competing for the same GitHub Pages deployment. Docs now use artifact-based Pages deployment while Helm charts publish to GHCR via OCI registries.

Users install charts with: helm install my-media-stack oci://ghcr.io/robbeverhelst/charts/preparr --version X.Y.Z

After merging: set the GHCR package to public visibility and update Artifact Hub to track oci://ghcr.io/robbeverhelst/charts/preparr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Helm installation instructions to use OCI registry URLs instead of traditional Helm repository commands across all documentation.

* **Chores**
  * Updated CI/CD workflow to publish Helm charts to OCI registry (GHCR) instead of Helm repository-based distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->