### PR TITLE
feat(bazarr): Add language profiles support

### DIFF
--- a/helm/preparr/values-e2e.yaml
+++ b/helm/preparr/values-e2e.yaml
@@ -306,6 +306,21 @@ bazarr:
           name: "English"
         - code: "nl"
           name: "Dutch"
+      languageProfiles:
+        - name: "Default"
+          cutoff: 1
+          items:
+            - language: "en"
+              forced: false
+              hi: false
+            - language: "nl"
+              forced: false
+              hi: true
+          mustContain: ""
+          mustNotContain: ""
+      defaultProfiles:
+        series: "Default"
+        movies: "Default"
       providers:
         - name: "opensubtitlescom"
           enabled: true

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -80,6 +80,28 @@ export const BazarrSubtitleDefaultsSchema = z.object({
   searchOnDownload: z.boolean().default(true),
 })
 
+export const BazarrLanguageProfileItemSchema = z.object({
+  language: z.string(),
+  forced: z.boolean().default(false),
+  hi: z.boolean().default(false),
+  audio_exclude: z.boolean().default(false),
+})
+
+export const BazarrLanguageProfileSchema = z.object({
+  name: z.string(),
+  cutoff: z.number().nullable().optional(),
+  items: z.array(BazarrLanguageProfileItemSchema).min(1),
+  mustContain: z.string().default(''),
+  mustNotContain: z.string().default(''),
+  originalFormat: z.boolean().nullable().optional(),
+  tag: z.string().nullable().optional(),
+})
+
+export const BazarrDefaultProfilesSchema = z.object({
+  series: z.string().optional(),
+  movies: z.string().optional(),
+})
+
 export const BazarrConfigSchema = z
   .object({
     sonarr: z
@@ -95,6 +117,8 @@ export const BazarrConfigSchema = z
       })
       .optional(),
     languages: z.array(BazarrLanguageSchema).default([]),
+    languageProfiles: z.array(BazarrLanguageProfileSchema).default([]),
+    defaultProfiles: BazarrDefaultProfilesSchema.optional(),
     providers: z.array(BazarrProviderSchema).default([]),
     subtitleDefaults: BazarrSubtitleDefaultsSchema.optional(),
   })
@@ -407,6 +431,9 @@ export type QBittorrentConfig = z.infer<typeof QBittorrentConfigSchema>
 export type BazarrLanguage = z.infer<typeof BazarrLanguageSchema>
 export type BazarrProvider = z.infer<typeof BazarrProviderSchema>
 export type BazarrSubtitleDefaults = z.infer<typeof BazarrSubtitleDefaultsSchema>
+export type BazarrLanguageProfileItem = z.infer<typeof BazarrLanguageProfileItemSchema>
+export type BazarrLanguageProfile = z.infer<typeof BazarrLanguageProfileSchema>
+export type BazarrDefaultProfiles = z.infer<typeof BazarrDefaultProfilesSchema>
 export type BazarrConfig = z.infer<typeof BazarrConfigSchema>
 export type AppConfig = z.infer<typeof AppConfigSchema>
 export type Config = z.infer<typeof ConfigSchema>

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -1,6 +1,7 @@
 // Import all step classes
 
 import { BazarrIntegrationStep } from '@/steps/bazarr/bazarr-integration'
+import { BazarrLanguageProfilesStep } from '@/steps/bazarr/bazarr-language-profiles'
 import { BazarrLanguagesStep } from '@/steps/bazarr/bazarr-languages'
 import { BazarrProvidersStep } from '@/steps/bazarr/bazarr-providers'
 import { BazarrConnectivityStep } from '@/steps/connectivity/bazarr-connectivity'
@@ -88,6 +89,7 @@ export class ConfigurationEngine {
       this.registry.register(new BazarrIntegrationStep())
       this.registry.register(new BazarrLanguagesStep())
       this.registry.register(new BazarrProvidersStep())
+      this.registry.register(new BazarrLanguageProfilesStep())
 
       logger.info('Configuration steps registered successfully', {
         totalSteps: this.registry.getAll().length,

--- a/src/steps/bazarr/bazarr-language-profiles.ts
+++ b/src/steps/bazarr/bazarr-language-profiles.ts
@@ -1,0 +1,206 @@
+import type { BazarrLanguageProfile } from '@/config/schema'
+import {
+  BazarrStep,
+  type ChangeRecord,
+  type StepContext,
+  type StepResult,
+  type Warning,
+} from '@/core/step'
+
+interface BazarrLanguageProfileState {
+  profileId: number
+  name: string
+  cutoff: number | null
+  items: Array<{
+    language: string
+    forced: boolean
+    hi: boolean
+  }>
+  mustContain: string
+  mustNotContain: string
+}
+
+export class BazarrLanguageProfilesStep extends BazarrStep {
+  readonly name = 'bazarr-language-profiles'
+  readonly description = 'Configure Bazarr language profiles'
+  readonly dependencies: string[] = ['bazarr-languages']
+  readonly mode: 'init' | 'sidecar' | 'both' = 'sidecar'
+
+  private getProfilesConfig(context: StepContext): BazarrLanguageProfile[] {
+    return context.config.app?.bazarr?.languageProfiles ?? []
+  }
+
+  private getDefaultProfilesConfig(context: StepContext): {
+    series: string | undefined
+    movies: string | undefined
+  } {
+    const defaults = context.config.app?.bazarr?.defaultProfiles
+    return {
+      series: defaults?.series,
+      movies: defaults?.movies,
+    }
+  }
+
+  validatePrerequisites(context: StepContext): boolean {
+    return this.getProfilesConfig(context).length > 0
+  }
+
+  async readCurrentState(context: StepContext): Promise<BazarrLanguageProfileState[]> {
+    try {
+      const profiles = await this.client.getLanguageProfiles()
+      return profiles.map((p) => ({
+        profileId: p.profileId,
+        name: p.name,
+        cutoff: p.cutoff,
+        items: p.items.map((item) => ({
+          language: item.language,
+          forced: item.forced === 'True',
+          hi: item.hi === 'True',
+        })),
+        mustContain: p.mustContain,
+        mustNotContain: p.mustNotContain,
+      }))
+    } catch (error) {
+      context.logger.debug('Failed to read Bazarr language profiles state', { error })
+      return []
+    }
+  }
+
+  protected getDesiredState(context: StepContext): BazarrLanguageProfile[] {
+    return this.getProfilesConfig(context)
+  }
+
+  compareAndPlan(
+    current: BazarrLanguageProfileState[],
+    desired: BazarrLanguageProfile[],
+  ): ChangeRecord[] {
+    const changes: ChangeRecord[] = []
+
+    const currentByName = new Map(current.map((p) => [p.name, p]))
+    const desiredNames = new Set(desired.map((p) => p.name))
+
+    // Check for new profiles or updates
+    for (const profile of desired) {
+      const existing = currentByName.get(profile.name)
+
+      if (!existing) {
+        changes.push({
+          type: 'create',
+          resource: 'bazarr-language-profile',
+          identifier: profile.name,
+          details: { itemCount: profile.items.length },
+        })
+      } else {
+        // Check if profile needs update
+        const needsUpdate = this.profileNeedsUpdate(existing, profile)
+        if (needsUpdate) {
+          changes.push({
+            type: 'update',
+            resource: 'bazarr-language-profile',
+            identifier: profile.name,
+            details: { itemCount: profile.items.length },
+          })
+        }
+      }
+    }
+
+    // Check for profiles to remove (not in desired state)
+    for (const name of currentByName.keys()) {
+      if (!desiredNames.has(name)) {
+        changes.push({
+          type: 'delete',
+          resource: 'bazarr-language-profile',
+          identifier: name,
+        })
+      }
+    }
+
+    return changes
+  }
+
+  private profileNeedsUpdate(
+    current: BazarrLanguageProfileState,
+    desired: BazarrLanguageProfile,
+  ): boolean {
+    // Compare cutoff
+    if (current.cutoff !== (desired.cutoff ?? null)) return true
+
+    // Compare mustContain/mustNotContain
+    if (current.mustContain !== (desired.mustContain ?? '')) return true
+    if (current.mustNotContain !== (desired.mustNotContain ?? '')) return true
+
+    // Compare items
+    if (current.items.length !== desired.items.length) return true
+
+    for (let i = 0; i < current.items.length; i++) {
+      const currentItem = current.items[i]
+      const desiredItem = desired.items[i]
+
+      if (!currentItem || !desiredItem) return true
+      if (currentItem.language !== desiredItem.language) return true
+      if (currentItem.forced !== (desiredItem.forced ?? false)) return true
+      if (currentItem.hi !== (desiredItem.hi ?? false)) return true
+    }
+
+    return false
+  }
+
+  async executeChanges(changes: ChangeRecord[], context: StepContext): Promise<StepResult> {
+    const errors: Error[] = []
+    const warnings: Warning[] = []
+
+    try {
+      if (changes.length > 0) {
+        const desired = this.getDesiredState(context)
+        context.logger.info('Configuring Bazarr language profiles...', {
+          profileCount: desired.length,
+        })
+
+        await this.client.configureLanguageProfiles(desired)
+
+        // Configure default profiles if specified
+        const defaultProfiles = this.getDefaultProfilesConfig(context)
+        if (defaultProfiles.series || defaultProfiles.movies) {
+          await this.client.configureDefaultProfiles(defaultProfiles.series, defaultProfiles.movies)
+        }
+
+        context.logger.info('Bazarr language profiles configured successfully', {
+          profiles: desired.map((p) => p.name).join(', '),
+        })
+      }
+
+      return {
+        success: true,
+        changes,
+        errors,
+        warnings,
+      }
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error))
+      errors.push(err)
+      context.logger.error('Failed to configure Bazarr language profiles', {
+        error: err.message,
+      })
+      return {
+        success: false,
+        changes,
+        errors,
+        warnings,
+      }
+    }
+  }
+
+  async verifySuccess(context: StepContext): Promise<boolean> {
+    try {
+      const current = await this.readCurrentState(context)
+      const desired = this.getDesiredState(context)
+
+      if (desired.length === 0) return true
+
+      const currentNames = new Set(current.map((p) => p.name))
+      return desired.every((profile) => currentNames.has(profile.name))
+    } catch {
+      return false
+    }
+  }
+}

--- a/tests/e2e/bazarr.test.ts
+++ b/tests/e2e/bazarr.test.ts
@@ -181,6 +181,72 @@ describe('Bazarr Integration', () => {
     })
   })
 
+  describe('Language Profile Configuration', () => {
+    test('Bazarr has language profiles configured', async () => {
+      const result = await callBazarrApi<Array<Record<string, unknown>>>(
+        'bazarr',
+        '/system/languages/profiles',
+        { apiKey: BAZARR_API_KEY },
+      )
+
+      expect(result.ok).toBe(true)
+      expect(Array.isArray(result.data)).toBe(true)
+      expect(result.data!.length).toBeGreaterThan(0)
+    })
+
+    test('Bazarr language profile has correct structure', async () => {
+      const result = await callBazarrApi<Array<Record<string, unknown>>>(
+        'bazarr',
+        '/system/languages/profiles',
+        { apiKey: BAZARR_API_KEY },
+      )
+
+      expect(result.ok).toBe(true)
+      const profiles = result.data ?? []
+
+      if (profiles.length > 0) {
+        const profile = profiles[0]
+        expect(profile.profileId).toBeDefined()
+        expect(profile.name).toBeDefined()
+        expect(Array.isArray(profile.items)).toBe(true)
+      }
+    })
+
+    test('Bazarr has Default profile configured', async () => {
+      const result = await callBazarrApi<Array<Record<string, unknown>>>(
+        'bazarr',
+        '/system/languages/profiles',
+        { apiKey: BAZARR_API_KEY },
+      )
+
+      const profiles = result.data ?? []
+      const defaultProfile = profiles.find((p) => p.name === 'Default')
+      expect(defaultProfile).toBeDefined()
+    })
+
+    test('Bazarr has default profile for series configured', async () => {
+      const result = await callBazarrApi<Record<string, unknown>>('bazarr', '/system/settings', {
+        apiKey: BAZARR_API_KEY,
+      })
+
+      expect(result.ok).toBe(true)
+      const generalSettings = result.data?.general as Record<string, unknown> | undefined
+      expect(generalSettings?.serie_default_profile).toBeDefined()
+      expect(generalSettings?.serie_default_profile).not.toBeNull()
+    })
+
+    test('Bazarr has default profile for movies configured', async () => {
+      const result = await callBazarrApi<Record<string, unknown>>('bazarr', '/system/settings', {
+        apiKey: BAZARR_API_KEY,
+      })
+
+      expect(result.ok).toBe(true)
+      const generalSettings = result.data?.general as Record<string, unknown> | undefined
+      expect(generalSettings?.movie_default_profile).toBeDefined()
+      expect(generalSettings?.movie_default_profile).not.toBeNull()
+    })
+  })
+
   describe('Provider Configuration', () => {
     test('Bazarr has providers configured', async () => {
       const result = await callBazarrApi<Record<string, unknown>>('bazarr', '/system/settings', {


### PR DESCRIPTION
## Summary

Implement support for configuring Bazarr language profiles via PrepArr config. Users can now define language profiles with customizable cutoff, forced subtitles, and hearing impaired settings. Default profiles can be assigned for series and movies.

## Changes

- Add language profile schemas and types to config
- Implement BazarrManager methods for language profile configuration
- Create BazarrLanguageProfilesStep with full reconciliation support
- Add comprehensive E2E tests for profile configuration

Resolves #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Bazarr language profile management supporting customizable language selections, cutoff preferences, and forced/required subtitle handling.
  * Introduced automatic default profile assignment for series and movie libraries with profile resolution and validation.

* **Tests**
  * Added comprehensive end-to-end tests validating language profile configuration, profile structure, and default profile application to series/movie settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->