### PR TITLE
fix(bazarr): write provider credentials and enable default profiles

### DIFF
--- a/src/steps/bazarr/bazarr-language-profiles.ts
+++ b/src/steps/bazarr/bazarr-language-profiles.ts
@@ -158,15 +158,15 @@ export class BazarrLanguageProfilesStep extends BazarrStep {
 
         await this.client.configureLanguageProfiles(desired)
 
-        // Configure default profiles if specified
-        const defaultProfiles = this.getDefaultProfilesConfig(context)
-        if (defaultProfiles.series || defaultProfiles.movies) {
-          await this.client.configureDefaultProfiles(defaultProfiles.series, defaultProfiles.movies)
-        }
-
         context.logger.info('Bazarr language profiles configured successfully', {
           profiles: desired.map((p) => p.name).join(', '),
         })
+      }
+
+      // Always configure default profiles if specified (idempotent, runs even when profiles unchanged)
+      const defaultProfiles = this.getDefaultProfilesConfig(context)
+      if (defaultProfiles.series || defaultProfiles.movies) {
+        await this.client.configureDefaultProfiles(defaultProfiles.series, defaultProfiles.movies)
       }
 
       return {


### PR DESCRIPTION
## Problem
#57 reported three Bazarr sidecar issues:

1. **Provider credentials never written** — OpenSubtitles username/password remain empty despite being in config
2. **Default profiles not applied** — serie_default_enabled and movie_default_enabled remain false
3. **Step execution appears skipped** — No step execution logs appear in sidecar output

## Root Causes
- `configureProviders()` only set enabled provider names, ignoring the `settings` field containing credentials
- `getProviders()` returned empty settings, preventing drift detection when credentials changed
- `configureDefaultProfiles()` set profile IDs but not the enabled flags, so Bazarr ignored them
- Default profile configuration was inside `if (changes.length > 0)`, so didn't run when profiles unchanged

## Solution
- Write provider-specific settings as `settings-{providerName}-{key}` form fields
- Read provider settings from Bazarr API response for comparison
- Set enabled flags alongside profile IDs in configureDefaultProfiles()
- Always call configureDefaultProfiles() regardless of profile changes (idempotent)
- Compare provider settings in BazarrProvidersStep to detect credential changes

Fixes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider-specific settings are now persisted through the configuration process alongside enablement status
  * Default series and movie profile configurations explicitly enable specified profiles when configured
  * Provider update detection has been enhanced to identify both enablement status changes and settings modifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->