### PR TITLE
fix(bazarr): use correct API format for bulk profile assignment

### DIFF
--- a/src/bazarr/client.ts
+++ b/src/bazarr/client.ts
@@ -515,10 +515,15 @@ export class BazarrManager {
 
     try {
       const url = this.buildUrl('/series')
+      const params = new URLSearchParams()
+      for (const id of seriesIds) {
+        params.append('seriesid', String(id))
+        params.append('profileid', String(profileId))
+      }
       const response = await fetch(url, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ seriesid: seriesIds, profileid: profileId }),
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params.toString(),
       })
 
       if (!response.ok) {
@@ -539,10 +544,15 @@ export class BazarrManager {
 
     try {
       const url = this.buildUrl('/movies')
+      const params = new URLSearchParams()
+      for (const id of movieIds) {
+        params.append('radarrid', String(id))
+        params.append('profileid', String(profileId))
+      }
       const response = await fetch(url, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ radarrid: movieIds, profileid: profileId }),
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params.toString(),
       })
 
       if (!response.ok) {


### PR DESCRIPTION
## Summary
Fixed HTTP 400 'Unknown action' error when bulk-assigning language profiles to series/movies. The PATCH /api/series endpoint handles actions (scan-disk, search-missing) and isn't for profile updates. Switched to POST with form-urlencoded paired fields matching Bazarr's Flask-RESTX parser.

## Changes
- Changed assignSeriesProfiles from PATCH to POST with form-urlencoded body
- Changed assignMoviesProfiles from PATCH to POST with form-urlencoded body
- Both now send paired fields: seriesid=X&profileid=Y&seriesid=Z&profileid=Y...

## Test plan
- [ ] PR CI passes (typecheck, lint, tests)
- [ ] E2E tests pass with Bazarr 1.5.3+
- [ ] Manual test: set applyToExisting: true and verify series/movies get assigned profiles

🤖 Generated with Claude Code