### PR TITLE
fix(bazarr): send individual requests for profile assignment

### DIFF
--- a/src/bazarr/client.ts
+++ b/src/bazarr/client.ts
@@ -513,28 +513,40 @@ export class BazarrManager {
     if (seriesIds.length === 0) return
     logger.info('Assigning profile to series...', { count: seriesIds.length, profileId })
 
-    try {
-      const url = this.buildUrl('/series')
-      const params = new URLSearchParams()
-      for (const id of seriesIds) {
+    let assigned = 0
+    let failed = 0
+    const url = this.buildUrl('/series')
+
+    for (const id of seriesIds) {
+      try {
+        const params = new URLSearchParams()
         params.append('seriesid', String(id))
         params.append('profileid', String(profileId))
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: params.toString(),
+        })
+        if (!response.ok) {
+          const body = await response.text()
+          logger.warn('Failed to assign profile to series', {
+            seriesId: id,
+            status: response.status,
+            body,
+          })
+          failed++
+        } else {
+          assigned++
+        }
+      } catch (error) {
+        logger.warn('Failed to assign profile to series', { seriesId: id, error })
+        failed++
       }
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: params.toString(),
-      })
+    }
 
-      if (!response.ok) {
-        const body = await response.text()
-        throw new Error(`HTTP ${response.status}: ${body}`)
-      }
-
-      logger.info('Series profiles assigned successfully', { count: seriesIds.length })
-    } catch (error) {
-      logger.error('Failed to assign series profiles', { error })
-      throw error
+    logger.info('Series profile assignment complete', { assigned, failed, total: seriesIds.length })
+    if (assigned === 0 && failed > 0) {
+      throw new Error(`Failed to assign profile to all ${failed} series`)
     }
   }
 
@@ -542,28 +554,40 @@ export class BazarrManager {
     if (movieIds.length === 0) return
     logger.info('Assigning profile to movies...', { count: movieIds.length, profileId })
 
-    try {
-      const url = this.buildUrl('/movies')
-      const params = new URLSearchParams()
-      for (const id of movieIds) {
+    let assigned = 0
+    let failed = 0
+    const url = this.buildUrl('/movies')
+
+    for (const id of movieIds) {
+      try {
+        const params = new URLSearchParams()
         params.append('radarrid', String(id))
         params.append('profileid', String(profileId))
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: params.toString(),
+        })
+        if (!response.ok) {
+          const body = await response.text()
+          logger.warn('Failed to assign profile to movie', {
+            radarrId: id,
+            status: response.status,
+            body,
+          })
+          failed++
+        } else {
+          assigned++
+        }
+      } catch (error) {
+        logger.warn('Failed to assign profile to movie', { radarrId: id, error })
+        failed++
       }
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: params.toString(),
-      })
+    }
 
-      if (!response.ok) {
-        const body = await response.text()
-        throw new Error(`HTTP ${response.status}: ${body}`)
-      }
-
-      logger.info('Movie profiles assigned successfully', { count: movieIds.length })
-    } catch (error) {
-      logger.error('Failed to assign movie profiles', { error })
-      throw error
+    logger.info('Movie profile assignment complete', { assigned, failed, total: movieIds.length })
+    if (assigned === 0 && failed > 0) {
+      throw new Error(`Failed to assign profile to all ${failed} movies`)
     }
   }
 


### PR DESCRIPTION
## Summary
Fixed HTTP 500 on bulk profile assignment by changing from one mega-request with all series/movies to individual per-item requests. Bazarr's POST handler calls list_missing_subtitles() per item and emits events per series/episode — 324 series in one request times out the server.

## Changes
- Changed assignSeriesProfiles() to loop and send one POST per series with per-item error handling
- Changed assignMoviesProfiles() to loop and send one POST per movie with per-item error handling
- Only throws if all assignments fail; partial success is allowed

## Test plan
- [ ] PR CI passes (typecheck, lint)
- [ ] E2E tests pass with Bazarr 1.5.3+
- [ ] Manual test: set applyToExisting: true with hundreds of unassigned series/movies

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile assignment reliability with enhanced per-item error handling and validation.
  * Better tracking and detailed logging for assignment successes and failures, allowing clearer visibility into which items succeeded or failed during the assignment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->