### PR TITLE
fix(bazarr): add audio_only_include field to language profiles

### DIFF
--- a/src/bazarr/client.ts
+++ b/src/bazarr/client.ts
@@ -17,6 +17,7 @@ interface BazarrLanguageProfileApi {
     forced: string
     hi: string
     audio_exclude: string
+    audio_only_include: string
   }>
   mustContain: string
   mustNotContain: string
@@ -393,6 +394,7 @@ export class BazarrManager {
             forced: item.forced ? 'True' : 'False',
             hi: item.hi ? 'True' : 'False',
             audio_exclude: item.audio_exclude ? 'True' : 'False',
+            audio_only_include: item.audio_only_include ? 'True' : 'False',
           })),
           mustContain: profile.mustContain ?? '',
           mustNotContain: profile.mustNotContain ?? '',

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -85,6 +85,7 @@ export const BazarrLanguageProfileItemSchema = z.object({
   forced: z.boolean().default(false),
   hi: z.boolean().default(false),
   audio_exclude: z.boolean().default(false),
+  audio_only_include: z.boolean().default(false),
 })
 
 export const BazarrLanguageProfileSchema = z.object({

--- a/src/steps/bazarr/bazarr-language-profiles.ts
+++ b/src/steps/bazarr/bazarr-language-profiles.ts
@@ -15,6 +15,8 @@ interface BazarrLanguageProfileState {
     language: string
     forced: boolean
     hi: boolean
+    audio_exclude: boolean
+    audio_only_include: boolean
   }>
   mustContain: string
   mustNotContain: string
@@ -64,6 +66,8 @@ export class BazarrLanguageProfilesStep extends BazarrStep {
           language: item.language,
           forced: item.forced === 'True',
           hi: item.hi === 'True',
+          audio_exclude: item.audio_exclude === 'True',
+          audio_only_include: item.audio_only_include === 'True',
         })),
         mustContain: p.mustContain,
         mustNotContain: p.mustNotContain,
@@ -148,6 +152,8 @@ export class BazarrLanguageProfilesStep extends BazarrStep {
       if (currentItem.language !== desiredItem.language) return true
       if (currentItem.forced !== (desiredItem.forced ?? false)) return true
       if (currentItem.hi !== (desiredItem.hi ?? false)) return true
+      if (currentItem.audio_exclude !== (desiredItem.audio_exclude ?? false)) return true
+      if (currentItem.audio_only_include !== (desiredItem.audio_only_include ?? false)) return true
     }
 
     return false


### PR DESCRIPTION
Bazarr 1.5.3's list_missing_subtitles() accesses the audio_only_include field on every profile item. Without this field, Bazarr throws KeyError causing POST /api/series to return 500, background subtitle scans to crash, and wanted subtitles to remain empty.

Fixes: Wanted subtitles remain empty even after profile assignment
Closes: #65

🤖 Generated with Claude Code