### PR TITLE
Add default resource requests/limits for injected containers

### DIFF
--- a/helm/preparr/templates/bazarr.yaml
+++ b/helm/preparr/templates/bazarr.yaml
@@ -109,6 +109,10 @@ spec:
             {{- else }}
             value: {{ .Values.postgresql.auth.password | quote }}
             {{- end }}
+        {{- with .Values.postgresql.waitContainer.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       - name: preparr-init
         image: {{ include "preparr.image" . }}
         imagePullPolicy: {{ .Values.preparr.image.pullPolicy }}
@@ -158,6 +162,10 @@ spec:
         - name: bazarr-config-file
           mountPath: /config/bazarr-config.json
           subPath: bazarr-config.json
+        {{- with .Values.preparr.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       containers:
       - name: preparr-sidecar
         image: {{ include "preparr.image" . }}
@@ -252,6 +260,10 @@ spec:
           subPath: bazarr-config.json
         {{- with .Values.bazarr.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.preparr.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
         {{- end }}
       - name: bazarr
         image: "{{ .Values.bazarr.image.repository }}:{{ .Values.bazarr.image.tag }}"

--- a/helm/preparr/templates/prowlarr.yaml
+++ b/helm/preparr/templates/prowlarr.yaml
@@ -78,6 +78,10 @@ spec:
         env:
           - name: PGPASSWORD
             value: {{ .Values.postgresql.auth.password | quote }}
+        {{- with .Values.postgresql.waitContainer.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       - name: preparr-init
         image: {{ include "preparr.image" . }}
         imagePullPolicy: {{ .Values.preparr.image.pullPolicy }}
@@ -111,6 +115,10 @@ spec:
         - name: prowlarr-config-file
           mountPath: /config/prowlarr-config.json
           subPath: prowlarr-config.json
+        {{- with .Values.preparr.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       containers:
       - name: prowlarr
         image: "{{ .Values.prowlarr.image.repository }}:{{ .Values.prowlarr.image.tag }}"
@@ -202,6 +210,10 @@ spec:
             port: {{ .Values.preparr.health.port }}
           initialDelaySeconds: 60
           periodSeconds: 30
+        {{- with .Values.preparr.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       volumes:
       - name: prowlarr-config-volume
         emptyDir: {}

--- a/helm/preparr/templates/qbittorrent.yaml
+++ b/helm/preparr/templates/qbittorrent.yaml
@@ -104,6 +104,10 @@ spec:
         {{- with .Values.qbittorrent.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- with .Values.preparr.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       containers:
       - name: qbittorrent
         image: "{{ .Values.qbittorrent.image.repository }}:{{ .Values.qbittorrent.image.tag }}"

--- a/helm/preparr/templates/radarr.yaml
+++ b/helm/preparr/templates/radarr.yaml
@@ -78,6 +78,10 @@ spec:
         env:
           - name: PGPASSWORD
             value: {{ .Values.postgresql.auth.password | quote }}
+        {{- with .Values.postgresql.waitContainer.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       - name: preparr-init
         image: {{ include "preparr.image" . }}
         imagePullPolicy: {{ .Values.preparr.image.pullPolicy }}
@@ -113,6 +117,10 @@ spec:
           subPath: radarr-config.json
         {{- with .Values.radarr.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.preparr.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
         {{- end }}
       containers:
       - name: radarr
@@ -205,6 +213,10 @@ spec:
             port: {{ .Values.preparr.health.port }}
           initialDelaySeconds: 60
           periodSeconds: 30
+        {{- with .Values.preparr.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       {{- with .Values.radarr.extraContainers }}
       {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/helm/preparr/templates/sonarr.yaml
+++ b/helm/preparr/templates/sonarr.yaml
@@ -125,6 +125,10 @@ spec:
         env:
           - name: PGPASSWORD
             value: {{ .Values.postgresql.auth.password | quote }}
+        {{- with .Values.postgresql.waitContainer.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       - name: preparr-init
         image: {{ include "preparr.image" . }}
         imagePullPolicy: {{ .Values.preparr.image.pullPolicy }}
@@ -189,6 +193,10 @@ spec:
           subPath: sonarr-config.json
         {{- with .Values.sonarr.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.preparr.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
         {{- end }}
       containers:
       - name: sonarr
@@ -340,6 +348,10 @@ spec:
             port: {{ .Values.preparr.health.port }}
           initialDelaySeconds: 60
           periodSeconds: 30
+        {{- with .Values.preparr.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       {{- with .Values.sonarr.extraContainers }}
       {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/helm/preparr/values.yaml
+++ b/helm/preparr/values.yaml
@@ -20,6 +20,15 @@ preparr:
   health:
     port: 9001
 
+  # Resource limits for preparr-init and preparr-sidecar containers
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+
   # Logging configuration
   logLevel: info  # debug|info|warn|error
 
@@ -64,6 +73,16 @@ postgresql:
     limits:
       memory: "512Mi"
       cpu: "500m"
+
+  # Resource limits for the wait-for-postgres init container
+  waitContainer:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+      limits:
+        cpu: 50m
+        memory: 64Mi
 
   # Persistence configuration
   persistence:


### PR DESCRIPTION
## Summary
Add configurable default resources for preparr-init, preparr-sidecar, and wait-for-postgres containers to resolve ResourceQuota rejections in namespaces with compute quotas.

- preparr containers: 10m/32Mi requests, 100m/128Mi limits
- wait-for-postgres: 10m/16Mi requests, 50m/64Mi limits
- All values configurable via `preparr.resources` and `postgresql.waitContainer.resources`

Fixes #68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resource configuration options for service containers, enabling specification of CPU and memory requests and limits.
  * Resources can now be independently configured for each service deployment to optimize infrastructure utilization.

* **Chores**
  * Updated Helm configuration values to support flexible resource allocation across multiple deployment components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->