### PR TITLE
docs: add postgres log database env vars

### DIFF
--- a/docs/src/content/docs/configuration/environment-variables.md
+++ b/docs/src/content/docs/configuration/environment-variables.md
@@ -12,6 +12,8 @@ description: Complete reference for all PrepArr environment variables
 | `POSTGRES_USER` | No | `postgres` | PostgreSQL username |
 | `POSTGRES_PASSWORD` | Yes | - | PostgreSQL password |
 | `POSTGRES_DB` | No | `servarr` | PostgreSQL database name |
+| `POSTGRES_LOG_DATABASE_ENABLED` | No | `true` | Create a separate `_log` database for each Servarr instance |
+| `POSTGRES_SKIP_PROVISIONING` | No | `false` | Skip database/user provisioning (for pre-provisioned databases) |
 | `SERVARR_URL` | Yes | - | Full URL to Servarr application (e.g., `http://sonarr:8989`) |
 | `SERVARR_TYPE` | Yes | - | Service type: `sonarr`, `radarr`, `prowlarr`, `lidarr`, `readarr`, `qbittorrent`, `bazarr`, `auto` |
 | `SERVARR_ADMIN_USER` | No | `admin` | Admin username for Servarr |

--- a/docs/src/content/docs/reference/helm-values.md
+++ b/docs/src/content/docs/reference/helm-values.md
@@ -43,6 +43,7 @@ Find the chart on [ArtifactHub](https://artifacthub.io/packages/helm/preparr/pre
 | `postgresql.auth.database` | Default database | `servarr` |
 | `postgresql.service.type` | Service type | `ClusterIP` |
 | `postgresql.service.port` | Service port | `5432` |
+| `postgresql.logDatabaseEnabled` | Create a separate `_log` database for each Servarr instance | `true` |
 | `postgresql.persistence.enabled` | Enable persistent volume | `false` |
 | `postgresql.persistence.size` | Volume size | `8Gi` |
 | `postgresql.persistence.storageClass` | Storage class | `""` |


### PR DESCRIPTION
## Summary
- Add `POSTGRES_LOG_DATABASE_ENABLED` and `POSTGRES_SKIP_PROVISIONING` to the environment variables reference
- Add `postgresql.logDatabaseEnabled` to the Helm values reference

Follow-up to PR #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added PostgreSQL environment variables `POSTGRES_LOG_DATABASE_ENABLED` and `POSTGRES_SKIP_PROVISIONING` to configuration reference
  * Added Helm value `postgresql.logDatabaseEnabled` for managing separate log database creation per Servarr instance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->