### PR TITLE
fix(config): apply logDatabaseEnabled and skipProvisioning env overrides

### DIFF
--- a/src/bazarr/client.test.ts
+++ b/src/bazarr/client.test.ts
@@ -11,11 +11,16 @@ describe('BazarrManager language profile configuration', () => {
   })
 
   test('restarts Bazarr after creating the first language profiles', async () => {
+    let restarted = false
     const fetchMock = mock((input: RequestInfo | URL) => {
       const url = input.toString()
 
       if (url.includes('/api/system/languages/profiles')) {
-        return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+        // After restart, return the created profile to simulate cache reload
+        const data = restarted
+          ? [{ profileId: 1, name: 'Default', cutoff: 1, items: [], mustContain: '', mustNotContain: '', originalFormat: null, tag: null }]
+          : []
+        return Promise.resolve(new Response(JSON.stringify(data), { status: 200 }))
       }
 
       if (url.includes('/api/system/settings')) {
@@ -23,6 +28,7 @@ describe('BazarrManager language profile configuration', () => {
       }
 
       if (url.includes('/api/system?action=restart')) {
+        restarted = true
         return Promise.resolve(new Response('', { status: 204 }))
       }
 
@@ -55,8 +61,9 @@ describe('BazarrManager language profile configuration', () => {
     expect(calledUrls).toContain(
       'http://bazarr:6767/api/system?action=restart&apikey=0123456789abcdef0123456789abcdef',
     )
-    expect(calledUrls.at(-1)).toBe(
-      'http://bazarr:6767/api/system/status?apikey=0123456789abcdef0123456789abcdef',
+    // After restart, should check that language profiles are available
+    expect(calledUrls).toContain(
+      'http://bazarr:6767/api/system/languages/profiles?apikey=0123456789abcdef0123456789abcdef',
     )
   })
 

--- a/src/bazarr/client.test.ts
+++ b/src/bazarr/client.test.ts
@@ -1,0 +1,112 @@
+import type { Mock } from 'bun:test'
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { BazarrManager } from './client'
+
+describe('BazarrManager language profile configuration', () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    mock.restore()
+  })
+
+  test('restarts Bazarr after creating the first language profiles', async () => {
+    const fetchMock = mock((input: RequestInfo | URL) => {
+      const url = input.toString()
+
+      if (url.includes('/api/system/languages/profiles')) {
+        return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+      }
+
+      if (url.includes('/api/system/settings')) {
+        return Promise.resolve(new Response('', { status: 204 }))
+      }
+
+      if (url.includes('/api/system?action=restart')) {
+        return Promise.resolve(new Response('', { status: 204 }))
+      }
+
+      if (url.includes('/api/system/status')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ data: { bazarr_version: '1.5.5' } }), { status: 200 }),
+        )
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    }) as Mock<typeof fetch>
+
+    globalThis.fetch = fetchMock as typeof fetch
+
+    const manager = new BazarrManager({
+      url: 'http://bazarr:6767',
+      apiKey: '0123456789abcdef0123456789abcdef',
+    })
+
+    await manager.configureLanguageProfiles([
+      {
+        name: 'Default',
+        cutoff: 1,
+        items: [{ language: 'en' }, { language: 'nl', hi: true }],
+      },
+    ])
+
+    const calledUrls = fetchMock.mock.calls.map(([input]) => input.toString())
+
+    expect(calledUrls).toContain(
+      'http://bazarr:6767/api/system?action=restart&apikey=0123456789abcdef0123456789abcdef',
+    )
+    expect(calledUrls.at(-1)).toBe(
+      'http://bazarr:6767/api/system/status?apikey=0123456789abcdef0123456789abcdef',
+    )
+  })
+
+  test('does not restart Bazarr when language profiles already exist', async () => {
+    const fetchMock = mock((input: RequestInfo | URL) => {
+      const url = input.toString()
+
+      if (url.includes('/api/system/languages/profiles')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                profileId: 1,
+                name: 'Default',
+                cutoff: 1,
+                items: [],
+                mustContain: '',
+                mustNotContain: '',
+                originalFormat: null,
+                tag: null,
+              },
+            ]),
+            { status: 200 },
+          ),
+        )
+      }
+
+      if (url.includes('/api/system/settings')) {
+        return Promise.resolve(new Response('', { status: 204 }))
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    }) as Mock<typeof fetch>
+
+    globalThis.fetch = fetchMock as typeof fetch
+
+    const manager = new BazarrManager({
+      url: 'http://bazarr:6767',
+      apiKey: '0123456789abcdef0123456789abcdef',
+    })
+
+    await manager.configureLanguageProfiles([
+      {
+        name: 'Default',
+        cutoff: 1,
+        items: [{ language: 'en' }],
+      },
+    ])
+
+    const calledUrls = fetchMock.mock.calls.map(([input]) => input.toString())
+    expect(calledUrls.some((url) => url.includes('/api/system?action=restart'))).toBe(false)
+  })
+})

--- a/src/bazarr/client.test.ts
+++ b/src/bazarr/client.test.ts
@@ -18,7 +18,18 @@ describe('BazarrManager language profile configuration', () => {
       if (url.includes('/api/system/languages/profiles')) {
         // After restart, return the created profile to simulate cache reload
         const data = restarted
-          ? [{ profileId: 1, name: 'Default', cutoff: 1, items: [], mustContain: '', mustNotContain: '', originalFormat: null, tag: null }]
+          ? [
+              {
+                profileId: 1,
+                name: 'Default',
+                cutoff: 1,
+                items: [],
+                mustContain: '',
+                mustNotContain: '',
+                originalFormat: null,
+                tag: null,
+              },
+            ]
           : []
         return Promise.resolve(new Response(JSON.stringify(data), { status: 200 }))
       }

--- a/src/bazarr/client.test.ts
+++ b/src/bazarr/client.test.ts
@@ -72,10 +72,15 @@ describe('BazarrManager language profile configuration', () => {
     expect(calledUrls).toContain(
       'http://bazarr:6767/api/system?action=restart&apikey=0123456789abcdef0123456789abcdef',
     )
-    // After restart, should check that language profiles are available
-    expect(calledUrls).toContain(
-      'http://bazarr:6767/api/system/languages/profiles?apikey=0123456789abcdef0123456789abcdef',
-    )
+    // Verify language profiles were checked AFTER the restart
+    const restartIndex = calledUrls.findIndex((url) => url.includes('/api/system?action=restart'))
+    const profileCallIndexes = calledUrls
+      .map((url, index) => ({ url, index }))
+      .filter(({ url }) => url.includes('/api/system/languages/profiles'))
+      .map(({ index }) => index)
+
+    expect(profileCallIndexes.length).toBeGreaterThanOrEqual(2)
+    expect(profileCallIndexes.some((index) => index > restartIndex)).toBe(true)
   })
 
   test('does not restart Bazarr when language profiles already exist', async () => {

--- a/src/bazarr/client.ts
+++ b/src/bazarr/client.ts
@@ -86,6 +86,22 @@ export class BazarrManager {
     })
   }
 
+  private async restartSystem(): Promise<void> {
+    logger.info('Restarting Bazarr...')
+
+    try {
+      await fetch(this.buildUrl('/system?action=restart'), {
+        method: 'POST',
+      })
+    } catch (error) {
+      // Bazarr can drop the connection while restarting before sending a full response.
+      logger.debug('Bazarr restart request ended before a response was returned', { error })
+    }
+
+    await this.waitForStartup(60, 2000)
+    logger.info('Bazarr restart completed successfully')
+  }
+
   async testConnection(): Promise<boolean> {
     try {
       const response = await this.apiGet('/system/status')
@@ -415,6 +431,13 @@ export class BazarrManager {
       logger.info('Bazarr language profiles configured successfully', {
         profiles: profiles.map((p) => p.name).join(', '),
       })
+
+      if (existing.length === 0 && profiles.length > 0) {
+        logger.info(
+          'Restarting Bazarr after initial language profile creation to refresh the profile cache',
+        )
+        await this.restartSystem()
+      }
     } catch (error) {
       logger.error('Failed to configure Bazarr language profiles', { error })
       throw error

--- a/src/bazarr/client.ts
+++ b/src/bazarr/client.ts
@@ -89,13 +89,21 @@ export class BazarrManager {
   private async restartSystem(): Promise<void> {
     logger.info('Restarting Bazarr...')
 
+    let response: Response | undefined
     try {
-      await fetch(this.buildUrl('/system?action=restart'), {
+      response = await fetch(this.buildUrl('/system?action=restart'), {
         method: 'POST',
       })
     } catch (error) {
       // Bazarr can drop the connection while restarting before sending a full response.
       logger.debug('Bazarr restart request ended before a response was returned', { error })
+    }
+
+    if (response && !response.ok) {
+      const body = await response.text().catch(() => '')
+      throw new Error(
+        `Bazarr restart request failed: HTTP ${response.status}${body ? `: ${body}` : ''}`,
+      )
     }
 
     await this.waitForStartup(60, 2000)
@@ -123,7 +131,9 @@ export class BazarrManager {
       await Bun.sleep(retryDelay)
     }
 
-    logger.warn('Bazarr language profile cache did not populate in time', { expectedCount })
+    const message = 'Bazarr language profile cache did not populate in time'
+    logger.error(message, { expectedCount, maxRetries, retryDelay })
+    throw new Error(`${message} (expected at least ${expectedCount} profiles)`)
   }
 
   async testConnection(): Promise<boolean> {

--- a/src/bazarr/client.ts
+++ b/src/bazarr/client.ts
@@ -102,6 +102,30 @@ export class BazarrManager {
     logger.info('Bazarr restart completed successfully')
   }
 
+  private async waitForLanguageProfiles(
+    expectedCount: number,
+    maxRetries = 15,
+    retryDelay = 2000,
+  ): Promise<void> {
+    logger.info('Waiting for Bazarr language profile cache to populate...', { expectedCount })
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      const profiles = await this.getLanguageProfiles()
+      if (profiles.length >= expectedCount) {
+        logger.info('Bazarr language profile cache is ready', { count: profiles.length })
+        return
+      }
+      logger.debug('Language profiles not yet available, retrying...', {
+        attempt,
+        found: profiles.length,
+        expected: expectedCount,
+      })
+      await Bun.sleep(retryDelay)
+    }
+
+    logger.warn('Bazarr language profile cache did not populate in time', { expectedCount })
+  }
+
   async testConnection(): Promise<boolean> {
     try {
       const response = await this.apiGet('/system/status')
@@ -437,6 +461,7 @@ export class BazarrManager {
           'Restarting Bazarr after initial language profile creation to refresh the profile cache',
         )
         await this.restartSystem()
+        await this.waitForLanguageProfiles(profiles.length)
       }
     } catch (error) {
       logger.error('Failed to configure Bazarr language profiles', { error })

--- a/src/config/merger.test.ts
+++ b/src/config/merger.test.ts
@@ -3,6 +3,7 @@ import {
   cleanConfig,
   createConfigurationSource,
   mergeConfigs,
+  mergeConfigsWithEnvOverride,
   validateRequiredFields,
 } from './merger'
 import type { Config } from './schema'
@@ -209,6 +210,77 @@ describe('mergeConfigs', () => {
 
     expect(result.config?.watch).toBe(false) // From CLI (overrides defaults)
     expect(result.config?.reconcileInterval).toBe(60) // From defaults
+  })
+})
+
+describe('mergeConfigsWithEnvOverride', () => {
+  test('env logDatabaseEnabled=false overrides default true', () => {
+    const defaults: Partial<Config> = {
+      postgres: {
+        host: 'localhost',
+        port: 5432,
+        username: 'postgres',
+        password: 'secret',
+        database: 'servarr',
+        logDatabaseEnabled: true,
+        skipProvisioning: false,
+      },
+    }
+
+    const envConfig: Partial<Config> = {
+      postgres: {
+        logDatabaseEnabled: false,
+      },
+    }
+
+    const result = mergeConfigsWithEnvOverride(defaults, null, envConfig, {})
+    expect(result.postgres?.logDatabaseEnabled).toBe(false)
+  })
+
+  test('env skipProvisioning=true overrides default false', () => {
+    const defaults: Partial<Config> = {
+      postgres: {
+        host: 'localhost',
+        port: 5432,
+        username: 'postgres',
+        password: 'secret',
+        database: 'servarr',
+        logDatabaseEnabled: true,
+        skipProvisioning: false,
+      },
+    }
+
+    const envConfig: Partial<Config> = {
+      postgres: {
+        skipProvisioning: true,
+      },
+    }
+
+    const result = mergeConfigsWithEnvOverride(defaults, null, envConfig, {})
+    expect(result.postgres?.skipProvisioning).toBe(true)
+  })
+
+  test('env logDatabaseEnabled=false overrides file config true', () => {
+    const defaults: Partial<Config> = {
+      postgres: {
+        logDatabaseEnabled: true,
+      },
+    }
+
+    const fileConfig: Partial<Config> = {
+      postgres: {
+        logDatabaseEnabled: true,
+      },
+    }
+
+    const envConfig: Partial<Config> = {
+      postgres: {
+        logDatabaseEnabled: false,
+      },
+    }
+
+    const result = mergeConfigsWithEnvOverride(defaults, fileConfig, envConfig, {})
+    expect(result.postgres?.logDatabaseEnabled).toBe(false)
   })
 })
 

--- a/src/config/merger.ts
+++ b/src/config/merger.ts
@@ -192,6 +192,18 @@ export function mergeConfigsWithEnvOverride(
       database: envConfig.postgres.database,
     } as unknown as Config['postgres']
   }
+  if (envConfig.postgres?.logDatabaseEnabled !== undefined) {
+    result.postgres = {
+      ...(result.postgres || {}),
+      logDatabaseEnabled: envConfig.postgres.logDatabaseEnabled,
+    } as unknown as Config['postgres']
+  }
+  if (envConfig.postgres?.skipProvisioning !== undefined) {
+    result.postgres = {
+      ...(result.postgres || {}),
+      skipProvisioning: envConfig.postgres.skipProvisioning,
+    } as unknown as Config['postgres']
+  }
 
   // Override sensitive servarr fields if provided in environment
   if (envConfig.servarr?.apiKey !== undefined) {


### PR DESCRIPTION
## Summary
- `mergeConfigsWithEnvOverride` was missing env override blocks for `postgres.logDatabaseEnabled` and `postgres.skipProvisioning`, so setting `POSTGRES_LOG_DATABASE_ENABLED=false` via env var was silently ignored — the default `true` always won
- This caused `postgres-users` to still grant permissions on `*_log` databases and `config.xml` to still contain `<PostgresLogDb>` even when log databases were disabled
- Adds 3 tests covering the env override behavior for both settings

Closes #109

## Test plan
- [x] `bun test --filter merger` — all 24 tests pass (3 new)
- [ ] Deploy to cluster and verify `prowlarr_log` permissions are no longer granted when `POSTGRES_LOG_DATABASE_ENABLED=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled environment-variable overrides for Postgres logging and provisioning settings.
  * Added automatic service restart and waiting for language-profile refresh when new language profiles are created.

* **Tests**
  * Added tests covering environment-variable configuration overrides.
  * Added tests verifying restart behavior and profile-refresh logic for language profile management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->