### PR TITLE
fix(config): write LogDbEnabled element in config.xml

### DIFF
--- a/src/servarr/client.test.ts
+++ b/src/servarr/client.test.ts
@@ -16,7 +16,7 @@ describe('ServarrManager config.xml generation', () => {
     Object.assign(process.env, originalEnv)
   })
 
-  test('omits PostgresLogDb when log databases are disabled', async () => {
+  test('writes LogDbEnabled=False and omits PostgresLogDb when log databases are disabled', async () => {
     const configPath = join(tmpdir(), `servarr-config-${Date.now()}.xml`)
     const manager = new ServarrManager(
       {
@@ -44,5 +44,37 @@ describe('ServarrManager config.xml generation', () => {
 
     expect(configXml).toContain('<PostgresMainDb>sonarr_main</PostgresMainDb>')
     expect(configXml).not.toContain('<PostgresLogDb>')
+    expect(configXml).toContain('<LogDbEnabled>False</LogDbEnabled>')
+  })
+
+  test('writes LogDbEnabled=True and includes PostgresLogDb when log databases are enabled', async () => {
+    const configPath = join(tmpdir(), `servarr-config-${Date.now()}.xml`)
+    const manager = new ServarrManager(
+      {
+        type: 'sonarr',
+        url: 'http://sonarr:8989',
+        apiKey: '0123456789abcdef0123456789abcdef',
+        adminUser: 'admin',
+        adminPassword: 'adminpass',
+        authenticationMethod: 'forms',
+      },
+      {
+        configPath,
+        logDatabaseEnabled: true,
+      },
+    )
+
+    process.env.POSTGRES_PASSWORD = 'postgres-secret'
+    process.env.POSTGRES_HOST = 'postgres'
+    process.env.POSTGRES_PORT = '5432'
+
+    await manager.writeConfigurationOnly()
+
+    const configXml = readFileSync(configPath, 'utf8')
+    rmSync(configPath)
+
+    expect(configXml).toContain('<PostgresMainDb>sonarr_main</PostgresMainDb>')
+    expect(configXml).toContain('<PostgresLogDb>sonarr_log</PostgresLogDb>')
+    expect(configXml).toContain('<LogDbEnabled>True</LogDbEnabled>')
   })
 })

--- a/src/servarr/client.ts
+++ b/src/servarr/client.ts
@@ -633,6 +633,7 @@ export class ServarrManager {
       ? `
   <PostgresLogDb>${databases.log}</PostgresLogDb>`
       : ''
+    const logDbEnabled = this.logDatabaseEnabled ? 'True' : 'False'
 
     const configXml = `<Config>
   <BindAddress>*</BindAddress>
@@ -645,6 +646,7 @@ export class ServarrManager {
   <AuthenticationRequired>Enabled</AuthenticationRequired>
   <Branch>main</Branch>
   <LogLevel>info</LogLevel>
+  <LogDbEnabled>${logDbEnabled}</LogDbEnabled>
   <SslCertPath></SslCertPath>
   <SslCertPassword></SslCertPassword>
   <UrlBase></UrlBase>


### PR DESCRIPTION
## Summary
- Adds `<LogDbEnabled>False</LogDbEnabled>` to config.xml when `logDatabaseEnabled: false`, which tells *arr apps to disable database logging entirely
- Omitting `<PostgresLogDb>` alone (from v0.19.3) doesn't work — the apps fall back to a default log DB name and crash if it doesn't exist
- Adds test for the enabled case to verify both `<LogDbEnabled>True</LogDbEnabled>` and `<PostgresLogDb>` are present

Refs #109

## Test plan
- [x] Unit tests pass for both enabled and disabled cases
- [ ] E2E tests pass in CI
- [ ] Deploy with `logDatabaseEnabled: false` and verify *arr apps start without a log database

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for log database configuration scenarios, verifying correct behavior for both enabled and disabled states with PostgreSQL database parameter validation.

* **Improvements**
  * Enhanced configuration generation to properly include log database enabled status in configuration output and conditionally apply database configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->