### PR TITLE
fix(helm): add existingSecret support for POSTGRES_PASSWORD in radarr and prowlarr

### DIFF
--- a/helm/preparr/templates/prowlarr.yaml
+++ b/helm/preparr/templates/prowlarr.yaml
@@ -93,7 +93,14 @@ spec:
         - name: POSTGRES_USER
           value: {{ .Values.postgresql.auth.username | quote }}
         - name: POSTGRES_PASSWORD
+          {{- if .Values.postgresql.auth.existingSecret }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "preparr.postgresql.secretName" . }}
+              key: {{ .Values.postgresql.auth.secretKeys.adminPasswordKey | default "password" }}
+          {{- else }}
           value: {{ .Values.postgresql.auth.password | quote }}
+          {{- end }}
         - name: POSTGRES_DB
           value: {{ .Values.postgresql.auth.database | quote }}
         - name: POSTGRES_LOG_DATABASE_ENABLED
@@ -160,7 +167,14 @@ spec:
         - name: POSTGRES_USER
           value: {{ .Values.postgresql.auth.username | quote }}
         - name: POSTGRES_PASSWORD
+          {{- if .Values.postgresql.auth.existingSecret }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "preparr.postgresql.secretName" . }}
+              key: {{ .Values.postgresql.auth.secretKeys.adminPasswordKey | default "password" }}
+          {{- else }}
           value: {{ .Values.postgresql.auth.password | quote }}
+          {{- end }}
         - name: POSTGRES_DB
           value: "prowlarr_main"
         - name: POSTGRES_LOG_DATABASE_ENABLED

--- a/helm/preparr/templates/radarr.yaml
+++ b/helm/preparr/templates/radarr.yaml
@@ -93,7 +93,14 @@ spec:
         - name: POSTGRES_USER
           value: {{ .Values.postgresql.auth.username | quote }}
         - name: POSTGRES_PASSWORD
+          {{- if .Values.postgresql.auth.existingSecret }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "preparr.postgresql.secretName" . }}
+              key: {{ .Values.postgresql.auth.secretKeys.adminPasswordKey | default "password" }}
+          {{- else }}
           value: {{ .Values.postgresql.auth.password | quote }}
+          {{- end }}
         - name: POSTGRES_DB
           value: {{ .Values.postgresql.auth.database | quote }}
         - name: POSTGRES_LOG_DATABASE_ENABLED
@@ -168,7 +175,14 @@ spec:
         - name: POSTGRES_USER
           value: {{ .Values.postgresql.auth.username | quote }}
         - name: POSTGRES_PASSWORD
+          {{- if .Values.postgresql.auth.existingSecret }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "preparr.postgresql.secretName" . }}
+              key: {{ .Values.postgresql.auth.secretKeys.adminPasswordKey | default "password" }}
+          {{- else }}
           value: {{ .Values.postgresql.auth.password | quote }}
+          {{- end }}
         - name: POSTGRES_DB
           value: "radarr_main"
         - name: POSTGRES_LOG_DATABASE_ENABLED


### PR DESCRIPTION
## Summary
- Adds `existingSecret` conditional support for `POSTGRES_PASSWORD` in radarr and prowlarr Helm templates
- Both init container and sidecar container env vars are updated in each template
- Matches the existing pattern already used in the sonarr template

Closes #106

## Test plan
- [ ] Deploy with `postgresql.auth.existingSecret` set and verify radarr/prowlarr pods pick up the secret reference
- [ ] Deploy without `existingSecret` and verify the plain `value:` fallback still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database password configuration now supports external Kubernetes Secrets for enhanced security and flexibility, while maintaining backward compatibility with direct value configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->