### PR TITLE
fix(helm): honour extraContainers for prowlarr, qbittorrent and bazarr

### DIFF
--- a/helm/preparr/Chart.yaml
+++ b/helm/preparr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: preparr
 description: Complete Infrastructure as Code for Servarr applications using Helm. Deploy your entire media stack (Prowlarr, Sonarr, Radarr, qBittorrent) with zero manual configuration - PrepArr automates user creation, API keys, service linking, and configuration management.
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "0.1.10"
 keywords:
   - servarr

--- a/helm/preparr/templates/bazarr.yaml
+++ b/helm/preparr/templates/bazarr.yaml
@@ -325,6 +325,9 @@ spec:
             port: 6767
           initialDelaySeconds: 30
           periodSeconds: 10
+      {{- with .Values.bazarr.extraContainers }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       volumes:
       - name: bazarr-config-volume
         emptyDir: {}

--- a/helm/preparr/templates/prowlarr.yaml
+++ b/helm/preparr/templates/prowlarr.yaml
@@ -232,6 +232,9 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+      {{- with .Values.prowlarr.extraContainers }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       volumes:
       - name: prowlarr-config-volume
         emptyDir: {}

--- a/helm/preparr/templates/qbittorrent.yaml
+++ b/helm/preparr/templates/qbittorrent.yaml
@@ -131,6 +131,9 @@ spec:
             port: 8080
           initialDelaySeconds: 30
           periodSeconds: 10
+      {{- with .Values.qbittorrent.extraContainers }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       volumes:
       - name: qbittorrent-config-volume
         {{- if .Values.qbittorrent.configStorage.enabled }}


### PR DESCRIPTION
## Problem

`sonarr` and `radarr` render `.Values.<app>.extraContainers`; **`prowlarr`, `qbittorrent` and `bazarr` silently ignore it.**

This fails invisibly: `values.yaml` declares `extraContainers: []` for all of them, so the values validate and pass through Helm without complaint — they're simply never rendered.

Found while wiring exportarr metric sidecars. `helm get values` showed the sidecar present for all four *arr apps, but `helm get manifest` told the truth:

```
radarr       contains exportarr container: True
sonarr       contains exportarr container: True
prowlarr     contains exportarr container: False
qbittorrent  contains exportarr container: False
```

Net effect: Prowlarr produced no Prometheus metrics at all, with nothing anywhere reporting an error.

## Fix

Adds the same three-line block the working templates already use, immediately before `volumes:` in each of the three affected templates:

```gotemplate
{{- with .Values.<app>.extraContainers }}
{{- toYaml . | nindent 6 }}
{{- end }}
```

No values changes needed — `extraContainers: []` is already declared for every app.

## Verification

`helm template` with a sidecar supplied for all five apps:

```
✓ bazarr       name: exportarr
✓ prowlarr     name: exportarr
✓ qbittorrent  name: qbit-exporter
✓ radarr       name: exportarr        <- unchanged
✓ sonarr       name: exportarr        <- unchanged
```

`helm lint` passes. Minor version bumped to 0.2.0 so consumers can pin the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring additional containers in Bazarr, Prowlarr, and qBittorrent deployments.
  * These containers can now be defined through Helm values and included alongside the primary service containers.

* **Chores**
  * Updated the Helm chart version to 0.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->