### PR TITLE
docs: move the site to preparr.robbeverhelst.com and add analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,12 +228,12 @@ Use the Helm chart or manual manifests with init containers + sidecars + ConfigM
 
 ## 📖 Documentation
 
-Full documentation is available at **[robbeverhelst.github.io/Preparr](https://robbeverhelst.github.io/Preparr)**.
+Full documentation is available at **[preparr.robbeverhelst.com](https://preparr.robbeverhelst.com)**.
 
-- **[Quick Start](https://robbeverhelst.github.io/Preparr/getting-started/quick-start/)** - Get up and running
-- **[Deployment Guides](https://robbeverhelst.github.io/Preparr/deployment/docker-compose/)** - Docker Compose, Kubernetes, Helm
-- **[Configuration Reference](https://robbeverhelst.github.io/Preparr/configuration/overview/)** - All configuration options
-- **[Troubleshooting](https://robbeverhelst.github.io/Preparr/troubleshooting/)** - Common issues and solutions
+- **[Quick Start](https://preparr.robbeverhelst.com/getting-started/quick-start/)** - Get up and running
+- **[Deployment Guides](https://preparr.robbeverhelst.com/deployment/docker-compose/)** - Docker Compose, Kubernetes, Helm
+- **[Configuration Reference](https://preparr.robbeverhelst.com/configuration/overview/)** - All configuration options
+- **[Troubleshooting](https://preparr.robbeverhelst.com/troubleshooting/)** - Common issues and solutions
 
 ## 🤝 Contributing
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -2,10 +2,19 @@ import { defineConfig } from 'astro/config'
 import starlight from '@astrojs/starlight'
 
 export default defineConfig({
-  site: 'https://robbeverhelst.github.io',
-  base: '/Preparr',
+  site: 'https://preparr.robbeverhelst.com',
   integrations: [
     starlight({
+      head: [
+        {
+          tag: 'script',
+          attrs: {
+            src: 'https://analytics.robbeverhelst.be/script.js',
+            'data-website-id': '3c20f066-4236-45b1-822c-0aa282a4c5d5',
+            defer: true,
+          },
+        },
+      ],
       title: 'PrepArr',
       social: [
         { icon: 'github', label: 'GitHub', href: 'https://github.com/robbeverhelst/Preparr' },

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,0 +1,1 @@
+preparr.robbeverhelst.com

--- a/docs/src/content/docs/configuration/bazarr.md
+++ b/docs/src/content/docs/configuration/bazarr.md
@@ -144,4 +144,4 @@ The sidecar then takes over to configure languages, providers, and integrations 
 | `BAZARR_URL` | Bazarr base URL (default: `http://localhost:6767` in standalone mode) |
 | `BAZARR_API_KEY` | Bazarr API key for authentication |
 
-See [Environment Variables](/Preparr/configuration/environment-variables/) for the full list.
+See [Environment Variables](/configuration/environment-variables/) for the full list.

--- a/docs/src/content/docs/configuration/environment-variables.md
+++ b/docs/src/content/docs/configuration/environment-variables.md
@@ -44,7 +44,7 @@ description: Complete reference for all PrepArr environment variables
 
 ## Notes
 
-- All environment variables can also be set via [CLI flags](/Preparr/reference/cli/) using kebab-case (e.g., `--postgres-host`)
+- All environment variables can also be set via [CLI flags](/reference/cli/) using kebab-case (e.g., `--postgres-host`)
 - `SERVARR_ADMIN_PASSWORD` is only required for Servarr types (sonarr, radarr, prowlarr, etc.), not for bazarr or qbittorrent
 - `SERVARR_TYPE=auto` attempts to detect the service type from the URL
 - When `SERVARR_TYPE=bazarr`, PrepArr manages Bazarr's `config.yaml` (not `config.xml`) and uses `BAZARR_URL`/`BAZARR_API_KEY` for API access

--- a/docs/src/content/docs/configuration/indexers.md
+++ b/docs/src/content/docs/configuration/indexers.md
@@ -15,7 +15,7 @@ When using Prowlarr to manage indexers centrally, set `prowlarrSync: true` in yo
 }
 ```
 
-This tells the sidecar to skip indexer management entirely, preventing conflicts with Prowlarr's indexer synchronization. See the [Prowlarr Sync guide](/Preparr/guides/prowlarr-sync/) for the full setup.
+This tells the sidecar to skip indexer management entirely, preventing conflicts with Prowlarr's indexer synchronization. See the [Prowlarr Sync guide](/guides/prowlarr-sync/) for the full setup.
 
 ## Manual Indexer Configuration
 

--- a/docs/src/content/docs/configuration/overview.md
+++ b/docs/src/content/docs/configuration/overview.md
@@ -55,18 +55,18 @@ downloadClients: [...]
 |----------|------|-------------|
 | `apiKey` | string | 32-character hex API key. Auto-generated if not provided. |
 | `prowlarrSync` | boolean | Enable Prowlarr indexer sync. Default: `false`. |
-| `rootFolders` | array | [Root folder definitions](/Preparr/configuration/root-folders/) |
-| `qualityProfiles` | array | [Quality profile definitions](/Preparr/configuration/quality-profiles/) |
-| `customFormats` | array | [Custom format definitions](/Preparr/configuration/custom-formats/) |
-| `downloadClients` | array | [Download client definitions](/Preparr/configuration/download-clients/) |
-| `indexers` | array | [Indexer definitions](/Preparr/configuration/indexers/) |
+| `rootFolders` | array | [Root folder definitions](/configuration/root-folders/) |
+| `qualityProfiles` | array | [Quality profile definitions](/configuration/quality-profiles/) |
+| `customFormats` | array | [Custom format definitions](/configuration/custom-formats/) |
+| `downloadClients` | array | [Download client definitions](/configuration/download-clients/) |
+| `indexers` | array | [Indexer definitions](/configuration/indexers/) |
 | `applications` | array | Prowlarr application sync configs |
-| `mediaManagement` | object | [Media management settings](/Preparr/configuration/media-management/) |
-| `naming` | object | [Naming conventions](/Preparr/configuration/naming/) |
+| `mediaManagement` | object | [Media management settings](/configuration/media-management/) |
+| `naming` | object | [Naming conventions](/configuration/naming/) |
 | `qualityDefinitions` | array | Quality size limits |
 | `releaseProfiles` | array | Release scoring (Sonarr only) |
 | `qbittorrent` | object | qBittorrent-specific settings |
-| `bazarr` | object | [Bazarr subtitle manager settings](/Preparr/configuration/bazarr/) |
+| `bazarr` | object | [Bazarr subtitle manager settings](/configuration/bazarr/) |
 
 ## How Reconciliation Works
 

--- a/docs/src/content/docs/deployment/docker-compose.md
+++ b/docs/src/content/docs/deployment/docker-compose.md
@@ -112,7 +112,7 @@ Docker Compose `depends_on` conditions enforce the correct order:
 
 ## Multi-Service Setup
 
-For a full Prowlarr + Sonarr + Radarr + qBittorrent stack, see the [Multi-Service Stack guide](/Preparr/guides/multi-service-stack/).
+For a full Prowlarr + Sonarr + Radarr + qBittorrent stack, see the [Multi-Service Stack guide](/guides/multi-service-stack/).
 
 ## Common Operations
 

--- a/docs/src/content/docs/deployment/helm.md
+++ b/docs/src/content/docs/deployment/helm.md
@@ -178,4 +178,4 @@ kubectl port-forward -n preparr svc/radarr 7878:7878
 kubectl port-forward -n preparr svc/prowlarr 9696:9696
 ```
 
-For the full list of configurable parameters, see the [Helm Values Reference](/Preparr/reference/helm-values/).
+For the full list of configurable parameters, see the [Helm Values Reference](/reference/helm-values/).

--- a/docs/src/content/docs/deployment/kubernetes.md
+++ b/docs/src/content/docs/deployment/kubernetes.md
@@ -3,7 +3,7 @@ title: Kubernetes
 description: Deploy PrepArr with raw Kubernetes manifests using init containers and sidecars
 ---
 
-For most Kubernetes deployments, the [Helm chart](/Preparr/deployment/helm/) is recommended. This guide covers raw manifest deployment for users who prefer direct control.
+For most Kubernetes deployments, the [Helm chart](/deployment/helm/) is recommended. This guide covers raw manifest deployment for users who prefer direct control.
 
 ## Prerequisites
 

--- a/docs/src/content/docs/getting-started/quick-start.md
+++ b/docs/src/content/docs/getting-started/quick-start.md
@@ -158,6 +158,6 @@ Now if you edit `sonarr-config.json`, the sidecar detects the change and applies
 
 ## Next steps
 
-- [Core Concepts](/Preparr/getting-started/concepts/) -- Understand how PrepArr works
-- [Multi-Service Stack](/Preparr/guides/multi-service-stack/) -- Add Radarr, Prowlarr, and qBittorrent
-- [Configuration Overview](/Preparr/configuration/overview/) -- Explore all configuration options
+- [Core Concepts](/getting-started/concepts/) -- Understand how PrepArr works
+- [Multi-Service Stack](/guides/multi-service-stack/) -- Add Radarr, Prowlarr, and qBittorrent
+- [Configuration Overview](/configuration/overview/) -- Explore all configuration options

--- a/docs/src/content/docs/guides/production.md
+++ b/docs/src/content/docs/guides/production.md
@@ -51,7 +51,7 @@ resources:
 
 ## Monitoring
 
-- Enable [health endpoints](/Preparr/guides/monitoring/) on all sidecars
+- Enable [health endpoints](/guides/monitoring/) on all sidecars
 - Configure liveness and readiness probes in your orchestrator
 - Set up alerting on unhealthy sidecars
 - Use `LOG_LEVEL=info` or `warn` in production (not `debug`)

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -6,7 +6,7 @@ hero:
   tagline: Infrastructure as Code for Servarr. Complete automation from fresh PostgreSQL to fully configured Servarr stacks.
   actions:
     - text: Get Started
-      link: /Preparr/getting-started/quick-start/
+      link: /getting-started/quick-start/
       icon: right-arrow
       variant: primary
     - text: View on GitHub
@@ -82,21 +82,21 @@ You write a JSON configuration file describing your desired state, and PrepArr h
   <Card title="Quick Start" icon="rocket">
     Get a fully configured Sonarr instance running with Docker Compose.
 
-    [Quick Start](/Preparr/getting-started/quick-start/)
+    [Quick Start](/getting-started/quick-start/)
   </Card>
   <Card title="Core Concepts" icon="open-book">
     Understand the three-container pattern, init vs sidecar modes, and the reconciliation loop.
 
-    [Concepts](/Preparr/getting-started/concepts/)
+    [Concepts](/getting-started/concepts/)
   </Card>
   <Card title="Deployment" icon="setting">
     Deploy with Docker Compose, Kubernetes, or Helm.
 
-    [Deployment](/Preparr/deployment/docker-compose/)
+    [Deployment](/deployment/docker-compose/)
   </Card>
   <Card title="Configuration" icon="document">
     Explore all configuration options for quality profiles, download clients, indexers, and more.
 
-    [Configuration](/Preparr/configuration/overview/)
+    [Configuration](/configuration/overview/)
   </Card>
 </CardGrid>

--- a/docs/src/content/docs/reference/examples.md
+++ b/docs/src/content/docs/reference/examples.md
@@ -300,4 +300,4 @@ volumes:
   - ./my-sonarr-config.json:/config/sonarr-config.json:ro
 ```
 
-See the [Quick Start](/Preparr/getting-started/quick-start/) guide for a complete walkthrough.
+See the [Quick Start](/getting-started/quick-start/) guide for a complete walkthrough.


### PR DESCRIPTION
Moves the documentation site off `robbeverhelst.github.io/Preparr` onto its own subdomain, matching what `unifi-reactor` now does at `reactor.robbeverhelst.com`, and adds the self-hosted Umami already used by the other sites.

## The part that mattered

A custom domain serves from the root, so `base: '/Preparr'` had to go. **That is the trap:** 24 links in the content were hardcoded with the `/Preparr/` prefix and would each have 404'd on the new domain — quick-start, every configuration page, both deployment guides, the examples reference.

They are rewritten to root-relative. Links to `github.com/robbeverhelst/Preparr` are deliberately untouched — those are repo URLs, not site paths, and a naive find-and-replace would have broken all four.

Verified on the built output rather than asserted: **zero** non-GitHub `/Preparr/` paths remain in `dist/`, 31 pages build clean, `dist/CNAME` is present, and the sitemap reflects the new origin.

## Analytics

Umami at `analytics.robbeverhelst.be`, via Starlight's `head` config. The website id is a public client identifier embedded in every page — not a secret — and the site already exists in Umami.

## Before this can go live

DNS is done: `preparr.robbeverhelst.com` is a CNAME to `robbeverhelst.github.io`, DNS-only so Pages can issue its certificate. After merge, the repo's Pages custom domain needs setting to `preparr.robbeverhelst.com` — GitHub reads it from `dist/CNAME` on deploy, and the old `github.io/Preparr` path 301s to the new domain, so existing links keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links throughout the site to use the new site structure.
  * Corrected navigation links for configuration, deployment, guides, references, and quick-start content.
  * Updated the README with the new documentation URL.
* **New Features**
  * Documentation is now available at `preparr.robbeverhelst.com`.
  * Added site analytics support to help improve the documentation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->